### PR TITLE
Configurable namespaces

### DIFF
--- a/charts/cx-operator/templates/configMap.yaml
+++ b/charts/cx-operator/templates/configMap.yaml
@@ -20,3 +20,15 @@ data:
         }
       }
     }
+
+    resources {
+      rulegroups = [
+        {{- range .Values.config.resources.rulegroups }}
+        {
+          namespace = {{ .namespace }}
+          buffer = {{ if .buffer }}{{ .buffer }}{{ else }}{{ $.Values.config.resources.defaultBuffer }}{{ end }}
+        },
+        {{- end }}
+      ]
+    }
+

--- a/charts/cx-operator/values.yaml
+++ b/charts/cx-operator/values.yaml
@@ -1,9 +1,14 @@
 config:
+  location: operator.conf
   coralogixApi:
     host: grpc-api.coralogix.com
     port: 443
     tls: true
-  location: operator.conf
+  resources:
+    defaultBuffer: 1024 # applied to all resources/namespaces;
+    rulegroups:
+      - namespace: default
+        # buffer: 1024
 image:
   pullPolicy: IfNotPresent
   repository: coralogixrepo


### PR DESCRIPTION
Makes it possible to list multiple namespaces from the helm configuration like this:

```yaml
  resources:
    rulegroups:
      - namespace: default
      - namespace: x
      - namespace: y
      - namespace: z
```