### PR TITLE
Revert "Use 1-based indexing for all RuleGroupSet sequences (#33)"

### DIFF
--- a/app/src/main/scala/com/coralogix/operator/logic/operators/rulegroupset/ModelTransformations.scala
+++ b/app/src/main/scala/com/coralogix/operator/logic/operators/rulegroupset/ModelTransformations.scala
@@ -175,10 +175,7 @@ object ModelTransformations {
     index: Int
   ): CreateRuleSubgroup =
     CreateRuleSubgroup(
-      rules = subGroup.orGroup.zipWithIndex
-        .map {
-          case (rule, idx) => toCreateRule(rule, idx + 1) // rules-api uses 1-based indexing
-        },
+      rules = subGroup.orGroup.zipWithIndex.map((toCreateRule _).tupled),
       enabled = None,
       order = Some(index)
     )
@@ -197,15 +194,8 @@ object ModelTransformations {
       creator = Some(Creator),
       ruleMatchers = toGrpcRuleMatchers(item.ruleGroup.matcher),
       ruleSubgroups = item.ruleGroup.andSequence.zipWithIndex
-        .map {
-          case (subGroup, idx) =>
-            toCreateRuleSubgroups(subGroup, idx + 1) // rules-api uses 1-based indexing
-        },
-      order = Some(
-        item.ruleGroup.order
-          .orElse(startOrder.map(_ + item.index))
-          .getOrElse(item.index)
-      )
+        .map((toCreateRuleSubgroups _).tupled),
+      order = item.ruleGroup.order.orElse(startOrder.map(_ + item.index))
     )
 
   private def defaultDescription(ctx: OperatorContext, setName: String): Optional[String] =

--- a/app/src/main/scala/com/coralogix/operator/logic/operators/rulegroupset/RuleGroupSetOperator.scala
+++ b/app/src/main/scala/com/coralogix/operator/logic/operators/rulegroupset/RuleGroupSetOperator.scala
@@ -48,13 +48,7 @@ object RuleGroupSetOperator {
                            ctx,
                            name,
                            item.spec.ruleGroupsSequence.zipWithIndex
-                             .map {
-                               case (ruleGroup, idx) =>
-                                 RuleGroupWithIndex(
-                                   ruleGroup,
-                                   idx + 1
-                                 ) // the rules-api uses 1-based indexing
-                             },
+                             .map { case (ruleGroup, idx) => RuleGroupWithIndex(ruleGroup, idx) },
                            item.spec.startOrder.toOption
                          )
               _ <- applyStatusUpdates(
@@ -75,11 +69,7 @@ object RuleGroupSetOperator {
               val mappings = status.groupIds.getOrElse(Vector.empty)
               val byName =
                 item.spec.ruleGroupsSequence.zipWithIndex.map {
-                  case (ruleGroup, idx) =>
-                    ruleGroup.name -> RuleGroupWithIndex(
-                      ruleGroup,
-                      idx + 1
-                    ) // rules-api uses 1-based indexing
+                  case (ruleGroup, idx) => ruleGroup.name -> RuleGroupWithIndex(ruleGroup, idx)
                 }.toMap
               val alreadyAssigned = mappingToMap(mappings)
               val toAdd = byName.keySet.diff(alreadyAssigned.keySet)

--- a/app/src/test/scala/com/coralogix/operator/logic/operators/rulegroupset/RuleGroupSetOperatorSpec.scala
+++ b/app/src/test/scala/com/coralogix/operator/logic/operators/rulegroupset/RuleGroupSetOperatorSpec.scala
@@ -53,12 +53,7 @@ object RuleGroupSetOperatorSpec extends DefaultRunnableSpec with RuleGroupSetOpe
                 _.ruleMatchers,
                 isNonEmpty
               ) &&
-              hasField[CreateRuleGroupRequest, Seq[_]](
-                "ruleSubgroups",
-                _.ruleSubgroups,
-                isNonEmpty
-              ) &&
-              hasField[CreateRuleGroupRequest, Option[Int]]("order", _.order, isSome(equalTo(1))),
+              hasField("ruleSubgroups", _.ruleSubgroups, isNonEmpty),
             Expectation.value(testSet1Group1Response)
           )
         ) {
@@ -114,11 +109,6 @@ object RuleGroupSetOperatorSpec extends DefaultRunnableSpec with RuleGroupSetOpe
                 "ruleMatchers",
                 _.ruleGroup,
                 isSome
-              ) &&
-              hasField[UpdateRuleGroupRequest, Option[Int]](
-                "order",
-                _.ruleGroup.flatMap(_.order),
-                isSome(equalTo(1))
               ),
             Expectation.value(testSet1Group1UpdateResponse)
           )


### PR DESCRIPTION
This reverts commit 03a175e3a5a6a12bca00dacd9a25bcd36b40bf2b.